### PR TITLE
Integrate dock flight profile

### DIFF
--- a/flight_profile/DockSim.py
+++ b/flight_profile/DockSim.py
@@ -66,11 +66,11 @@ class DockSim(object):
     INTERVAL_END  = 2  # End of time interval reached
     
     # Final simulation result conditions
-    OUTCOME_DNF = 1
-    OUTCOME_NO_FUEL = 2
-    OUTCOME_TOO_SLOW = 3
-    OUTCOME_TOO_FAST = 4
-    OUTCOME_SUCCESS = 5
+    OUTCOME_DNF      = "OUTCOME_DNF"
+    OUTCOME_NO_FUEL  = "OUTCOME_NO_FUEL"
+    OUTCOME_TOO_SLOW = "OUTCOME_TOO_SLOW"
+    OUTCOME_TOO_FAST = "OUTCOME_TOO_FAST"
+    OUTCOME_SUCCESS  = "OUTCOME_SUCCESS"
     
     def __init__(self, fp):
         """ Store the simulation parameters.

--- a/flight_profile/FlightProfile.py
+++ b/flight_profile/FlightProfile.py
@@ -51,12 +51,13 @@ class Text(pygame.sprite.DirtySprite):
     DEFAULT_FONT_SIZE = 100
     
     def __init__(self, pt, value="", size=DEFAULT_FONT_SIZE, font=DEFAULT_FONT,
-                       justify=LEFT|BOTTOM, color=Colors.WHITE, intervalsMs=(1000,0)):
+                       justify=LEFT|BOTTOM, color=Colors.WHITE, intervalsMs=(1000,0), shrinkToWidth=0):
         """ intervalMs is a list of (on, off, on, off, ...) time intervals used to toggle the text visibility """
         super(Text, self).__init__()
         
         self.pos = pt
         self.pointSize = size
+        self.fontName = font
         self.font = pygame.font.Font(font, self.pointSize)
         self.justify = justify
         self.color = color
@@ -65,6 +66,7 @@ class Text(pygame.sprite.DirtySprite):
         self.toggleTimeMs = 0
         self.rect = None  # required by sprite.draw()
         self._value = None
+        self.shrinkToWidth = shrinkToWidth
         self.setValue(value)  # sets _value and image
         
         self.visible=0
@@ -79,7 +81,22 @@ class Text(pygame.sprite.DirtySprite):
         self._value = value
         if color:
             self.color = color
-        self.image = self.font.render(self._value, True, self.color)
+        
+        # Create the text image
+        # If shrinkToWidth > 0, shrink the pointSize until it fits
+        ptSize = self.pointSize
+        font = self.font
+        while True:
+            textWidth = font.size(self._value)[0]
+            if self.shrinkToWidth == 0 or textWidth <= self.shrinkToWidth:
+                break
+#            self.image = font.render(self._value, True, self.color)
+            print("Text width", textWidth)
+            ptSize = int(ptSize * self.shrinkToWidth/textWidth)
+            print("Point size", ptSize)
+            font = pygame.font.Font(self.fontName, ptSize)
+        self.image = font.render(self._value, True, self.color)
+
         self.dirty = 1
 
         self.rect = self.image.get_rect()
@@ -302,7 +319,8 @@ class FlightProfileApp(object):
     TEXT_LAYER  = 2
     SHIP_LAYER  = 3
     
-    SCREEN_CENTER     = (960, 540)
+    SCREEN_SIZE       = (1920, 1080)
+    SCREEN_CENTER     = (SCREEN_SIZE[0]//2, SCREEN_SIZE[1]//2)
     FLIGHT_PATH_START = (400, 600)
     FLIGHT_PATH_END   = (1600, 750)
     
@@ -333,7 +351,7 @@ class FlightProfileApp(object):
     FLAME_DOWN_OFFSET = (-24, 21)
     
     OUTCOMES = {
-        DockSim.OUTCOME_DNF     : "Destination not reached due to negative forward velocity",
+        DockSim.OUTCOME_DNF     : "Destination not reached due to loss of all forward velocity",
         DockSim.OUTCOME_NO_FUEL : "Ran out of fuel before achieving proper docking velocity",
         DockSim.OUTCOME_TOO_SLOW: "Latch failure due to insufficient forward velocity",
         DockSim.OUTCOME_TOO_FAST: "Latch failure caused by excessive forward velocity",
@@ -546,7 +564,8 @@ class FlightProfileApp(object):
                     value=str(name),
                     size=int(GIANT_TEXT * 0.6),
                     color=Colors.WHITE,
-                    justify=Text.CENTER|Text.MIDDLE)
+                    justify=Text.CENTER|Text.MIDDLE,
+                    shrinkToWidth=int(self.SCREEN_SIZE[0]*0.9))
         self.blinkingTextGroup.add((text, nameText))
         
     def createPassFailText(self, passed=True, msg=None):
@@ -657,9 +676,10 @@ class FlightProfileApp(object):
                     self.animGroup.add(self.frontFlameDown)
             elif state.phase == DockSim.END_PHASE:
                 passed = self.dockSim.dockIsSuccessful()
-                msg = self.outcomeMessage(state)
-                self.createPassFailText(passed=passed, msg=msg)
-                self.reportPassFail(passed, state.tEnd, msg)
+#                 msg = self.outcomeMessage(state)
+                result = self.dockSim.outcome(state)
+                self.createPassFailText(passed=passed, msg=self.OUTCOMES[result])
+                self.reportPassFail(passed, state.tEnd, result)
         
         # Compute the fraction of the total trip distance that has been traversed,
         # and place the ship at that location
@@ -807,7 +827,7 @@ class FlightProfileApp(object):
             while cmd is None:
                 try:
                     cmd,args = self.workQueue.get_nowait()
-                    print("Got work ({},{})".format(repr(cmd), repr(args)))
+                    #print("Got work ({},{})".format(repr(cmd), repr(args)))
                 except Queue.Empty:
                     pass
                 updateProc()
@@ -815,7 +835,7 @@ class FlightProfileApp(object):
                 self.frameClock.tick(self.frameRate)
             
             if cmd == self.RUN_CMD:
-                print("RUN_CMD")
+                #print("RUN_CMD")
                 self.clearDisplay()
                 self.countDown()
                 self.clearDisplay()
@@ -827,17 +847,17 @@ class FlightProfileApp(object):
                 updateProc = self.update
                 #self.processLoop()  # stay in processLoop() until sim is complete
             elif cmd == self.READY_CMD:
-                print("READY_CMD")
+                #print("READY_CMD")
                 self.clearDisplay()
                 self.createReadyText()
                 updateProc = self.updateBlinkingText
             elif cmd == self.WELCOME_CMD:
-                print("WELCOME_CMD")
+                #print("WELCOME_CMD")
                 self.clearDisplay()
                 self.createWelcomeText(name=args[0])
                 updateProc = self.updateBlinkingText
             elif cmd == self.QUIT_CMD:
-                print("QUIT_CMD")
+                #print("QUIT_CMD")
                 self.clearDisplay()
                 self.clearBackground()
                 self.takeDownDisplay()

--- a/station/test/dock_test.sh
+++ b/station/test/dock_test.sh
@@ -1,12 +1,23 @@
-#!/bin/sh
+#!/bin/bash
+#
+# Run Flight Profile simulations forever (Ctl-C to quit)
+
 startSleep=10
 simSleep=15
 resetSleep=5
 
+java -jar /opt/wiremock/wiremock-1.48-standalone.jar --root-dir /opt/designchallenge2016/brata.station/wiremock --no-request-journal &
+wiremock_pid=$!
+trap "kill -9 $wiremock_pid $$" 2
+sleep 10
 DISPLAY=:0.0 python /opt/designchallenge2016/brata.station/bin/runstation -n dock01 &
+runstation_pid=$!
+trap "kill -9 $wiremock_pid $runstation_pid $$" 2
+
 sleep 10
 
 while true; do
+
    echo "Send start_challenge"
    http --json POST http://localhost:5000/rpi/start_challenge Content-type:application/json Accept:application/json team_name="Space Team"
    sleep $startSleep
@@ -37,7 +48,7 @@ while true; do
    echo "Send start_challenge"
    http --json POST http://localhost:5000/rpi/start_challenge Content-type:application/json Accept:application/json team_name="Hydrazine Hogs"
    sleep $startSleep
-   echo "Send post_challenge (out of fuel)"
+   echo "Send post_challenge (out of fuel in accel phase)"
    http --json POST http://localhost:5000/rpi/post_challenge Content-type:application/json Accept:application/json t_aft='8.2' t_coast='1' t_fore='13.1' a_aft='.15' a_fore='0.09' r_fuel='0.7' q_fuel='5' dist='15.0' v_min='0.01' v_max='0.1' v_init='0.0' t_sim='5'
    sleep $simSleep
    http --json GET http://localhost:5000/rpi/reset/31415 Content-type:text/html
@@ -51,4 +62,41 @@ while true; do
    sleep $simSleep
    http --json GET http://localhost:5000/rpi/reset/31415 Content-type:text/html
    sleep $resetSleep
+   
+   echo "Send start_challenge"
+   http --json POST http://localhost:5000/rpi/start_challenge Content-type:application/json Accept:application/json team_name="Team Whose Name Takes Up a Lot of Space"
+   sleep $startSleep
+   echo "Send post_challenge (out of fuel in decel phase - success)"
+   http --json POST http://localhost:5000/rpi/post_challenge Content-type:application/json Accept:application/json t_aft='3' t_coast='8' t_fore='13.1' a_aft='.15' a_fore='0.09' r_fuel='0.7' q_fuel='5' dist='15.0' v_min='0.01' v_max='0.1' v_init='0.0' t_sim='5'
+   sleep $simSleep
+   http --json GET http://localhost:5000/rpi/reset/31415 Content-type:text/html
+   sleep $resetSleep
+
+   echo "Send start_challenge"
+   http --json POST http://localhost:5000/rpi/start_challenge Content-type:application/json Accept:application/json team_name="Open the Pod Bay Doors Please, HAL"
+   sleep $startSleep
+   echo "Send post_challenge (out of fuel in decel phase - fail)"
+   http --json POST http://localhost:5000/rpi/post_challenge Content-type:application/json Accept:application/json t_aft='4' t_coast='12' t_fore='13.1' a_aft='.15' a_fore='0.09' r_fuel='0.7' q_fuel='5' dist='15.0' v_min='0.01' v_max='0.1' v_init='0.0' t_sim='5'
+   sleep $simSleep
+   http --json GET http://localhost:5000/rpi/reset/31415 Content-type:text/html
+   sleep $resetSleep
+
+   echo "Send start_challenge"
+   http --json POST http://localhost:5000/rpi/start_challenge Content-type:application/json Accept:application/json team_name="Team Whose Name is Designed Solely to Test the Limits of the Font Scaling Feature Built into This Screen Layout Function"
+   sleep $startSleep
+   echo "Send post_challenge (out of fuel in decel phase - fail)"
+   http --json POST http://localhost:5000/rpi/post_challenge Content-type:application/json Accept:application/json t_aft='4' t_coast='12' t_fore='13.1' a_aft='.15' a_fore='0.09' r_fuel='0.7' q_fuel='5' dist='15.0' v_min='0.01' v_max='0.1' v_init='0.0' t_sim='5'
+   sleep $simSleep
+   http --json GET http://localhost:5000/rpi/reset/31415 Content-type:text/html
+   sleep $resetSleep
+   
+   echo "Send start_challenge"
+   http --json POST http://localhost:5000/rpi/start_challenge Content-type:application/json Accept:application/json team_name="Team Whose Name is Designed Solely to Test the Limits of the Automatic Font Scaling Feature Built into This Screen Layout Function, Whose Purpose is to Make Sure the Team Name Fits on the Screen Without Getting Clipped"
+   sleep $startSleep
+   echo "Send post_challenge (tiny accel)"
+   http --json POST http://localhost:5000/rpi/post_challenge Content-type:application/json Accept:application/json t_aft='0.1' t_coast='0' t_fore='0' a_aft='.15' a_fore='0.09' r_fuel='0.7' q_fuel='20' dist='15.0' v_min='0.01' v_max='0.1' v_init='0.0' t_sim='5'
+   sleep $simSleep
+   http --json GET http://localhost:5000/rpi/reset/31415 Content-type:text/html
+   sleep $resetSleep
+
 done


### PR DESCRIPTION
DOCK:  
@jawaad-ahmad, @jaron42:  I changed the content of the `Submit` _fail_message_ field being returned from Dock stations.  It now contains a short string that should be easy to compare for scoring purposes:  The field will contain one of:
- OUTCOME_DNF
- OUTCOME_NO_FUEL
- OUTCOME_TOO_SLOW
- OUTCOME_TOO_FAST
- OUTCOME_SUCCESS

The only ones you really care about are:
- OUTCOME_SUCCESS:  Before this field was empty on a successful outcome.
- OUTCOME_DNF:  This means "Did Not Finish".  The velocity went to 0, so the elapsed time should be multiplied by the penalty factor.

Also in this commit:
- Minor embellishments to the Dock user experience
- An enhanced long-duration Dock testing script (does not require MS)
